### PR TITLE
Add new proposal types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Cargo.lock
 .env
 
 vendor/
+.DS_Store

--- a/src/airdrop.cairo
+++ b/src/airdrop.cairo
@@ -15,7 +15,7 @@ mod Airdrop {
     use governance::contract::Governance;
     use governance::traits::IGovernanceTokenDispatcher;
     use governance::traits::IGovernanceTokenDispatcherTrait;
-    use governance::contract::Governance::{governance_token_address,airdrop_claimed, merkle_root};
+    use governance::contract::Governance::{governance_token_address, airdrop_claimed, merkle_root};
 
     fn get_merkle_root() -> felt252 {
         let root = merkle_root::read();

--- a/src/contract.cairo
+++ b/src/contract.cairo
@@ -28,7 +28,8 @@ mod Governance {
         amm_address: ContractAddress,
         airdrop_claimed: LegacyMap::<ContractAddress, u128>,
         delegate_hash: LegacyMap::<ContractAddress, felt252>,
-        total_delegated_to: LegacyMap::<ContractAddress, u128>
+        total_delegated_to: LegacyMap::<ContractAddress, u128>,
+        merkle_root: felt252
     }
 
     // PROPOSALS

--- a/src/proposals.cairo
+++ b/src/proposals.cairo
@@ -66,7 +66,7 @@ mod Proposals {
 
     fn assert_correct_contract_type(contract_type: ContractType) {
         let contract_type_u: u64 = contract_type.try_into().unwrap();
-        assert(contract_type_u <= 2, 'invalid contract type')
+        assert(contract_type_u <= 4, 'invalid contract type')
     }
 
     fn assert_voting_in_progress(prop_id: felt252) {
@@ -83,7 +83,7 @@ mod Proposals {
         u256 { low, high }
     }
 
-    fn submit_proposal(impl_hash: felt252, to_upgrade: ContractType) -> felt252 {
+    fn submit_proposal(payload: felt252, to_upgrade: ContractType) -> felt252 {
         assert_correct_contract_type(to_upgrade);
         let govtoken_addr = governance_token_address::read();
         let caller = get_caller_address();
@@ -97,7 +97,7 @@ mod Proposals {
         assert(total_supply < res, 'not enough tokens to submit');
 
         let prop_id = get_free_prop_id();
-        let prop_details = PropDetails { impl_hash: impl_hash, to_upgrade: to_upgrade };
+        let prop_details = PropDetails { payload: payload, to_upgrade: to_upgrade };
         proposal_details::write(prop_id, prop_details);
 
         let current_block_number: u64 = get_block_info().unbox().block_number;
@@ -106,7 +106,7 @@ mod Proposals {
             .into();
         proposal_vote_ends::write(prop_id, end_block_number);
 
-        Governance::Proposed(prop_id, impl_hash, to_upgrade);
+        Governance::Proposed(prop_id, payload, to_upgrade);
         prop_id
     }
 

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -19,7 +19,8 @@ struct VoteCounts {
 
 type BlockNumber = felt252;
 type VoteStatus = felt252; // 0 = not voted, 1 = yay, -1 = nay
-type ContractType = felt252; // for Carmine 0 = amm, 1 = governance, 2 = CARM token, 3 = merkle tree root, 4 = no-op/signal vote
+type ContractType =
+    felt252; // for Carmine 0 = amm, 1 = governance, 2 = CARM token, 3 = merkle tree root, 4 = no-op/signal vote
 type OptionSide = felt252;
 type OptionType = felt252;
 

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -8,7 +8,7 @@ use core::serde::Serde;
 
 #[derive(Copy, Drop)]
 struct PropDetails {
-    impl_hash: felt252,
+    payload: felt252,
     to_upgrade: felt252,
 }
 
@@ -19,7 +19,7 @@ struct VoteCounts {
 
 type BlockNumber = felt252;
 type VoteStatus = felt252; // 0 = not voted, 1 = yay, -1 = nay
-type ContractType = felt252; // for Carmine 0 = amm, 1 = governance, 2 = CARM token
+type ContractType = felt252; // for Carmine 0 = amm, 1 = governance, 2 = CARM token, 3 = merkle tree root, 4 = no-op/signal vote
 type OptionSide = felt252;
 type OptionType = felt252;
 
@@ -27,7 +27,7 @@ impl StorageAccessPropDetails of StorageAccess<PropDetails> {
     fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<PropDetails> {
         Result::Ok(
             PropDetails {
-                impl_hash: StorageAccess::<felt252>::read(address_domain, base)?,
+                payload: StorageAccess::<felt252>::read(address_domain, base)?,
                 to_upgrade: storage_read_syscall(
                     address_domain, storage_address_from_base_and_offset(base, 1)
                 )?
@@ -38,7 +38,7 @@ impl StorageAccessPropDetails of StorageAccess<PropDetails> {
     fn write(
         address_domain: u32, base: StorageBaseAddress, value: PropDetails
     ) -> SyscallResult<()> {
-        StorageAccess::<felt252>::write(address_domain, base, value.impl_hash)?;
+        StorageAccess::<felt252>::write(address_domain, base, value.payload)?;
         storage_write_syscall(
             address_domain, storage_address_from_base_and_offset(base, 1), value.to_upgrade
         )
@@ -47,13 +47,13 @@ impl StorageAccessPropDetails of StorageAccess<PropDetails> {
 
 impl PropDetailsSerde of serde::Serde<PropDetails> {
     fn serialize(self: @PropDetails, ref output: array::Array<felt252>) {
-        self.impl_hash.serialize(ref output);
+        self.payload.serialize(ref output);
         self.to_upgrade.serialize(ref output);
     }
     fn deserialize(ref serialized: array::Span<felt252>) -> Option<PropDetails> {
         Option::Some(
             PropDetails {
-                impl_hash: serde::Serde::deserialize(ref serialized)?,
+                payload: serde::Serde::deserialize(ref serialized)?,
                 to_upgrade: serde::Serde::deserialize(ref serialized)?,
             }
         )

--- a/src/upgrades.cairo
+++ b/src/upgrades.cairo
@@ -11,7 +11,9 @@ mod Upgrades {
     use starknet::ContractAddress;
     use starknet::class_hash;
     use governance::proposals::Proposals;
-    use governance::contract::Governance::{proposal_applied, amm_address, governance_token_address, merkle_root};
+    use governance::contract::Governance::{
+        proposal_applied, amm_address, governance_token_address, merkle_root
+    };
 
     use governance::types::PropDetails;
 
@@ -44,15 +46,17 @@ mod Upgrades {
                 if (contract_type == 1) {
                     let impl_hash_classhash: ClassHash = impl_hash.try_into().unwrap();
                     syscalls::replace_class_syscall(impl_hash_classhash);
-                } else if (contract_type == 2){
+                } else if (contract_type == 2) {
                     let govtoken_addr = governance_token_address::read();
                     IGovernanceTokenDispatcher {
                         contract_address: govtoken_addr
                     }.upgrade(impl_hash);
-                } else if (contract_type == 3){
+                } else if (contract_type == 3) {
                     merkle_root::write(impl_hash);
                 } else {
-                    assert(contract_type == 4, 'invalid contract_type'); // type 4 is no-op, signal vote
+                    assert(
+                        contract_type == 4, 'invalid contract_type'
+                    ); // type 4 is no-op, signal vote
                 }
             }
         }


### PR DESCRIPTION
Adds proposal types for airdrop (3) where the payload is the merkle tree root and proposal type 4, which is no-op, useful for signal votes.