### PR TITLE
chore: move addresses class hashes to constants

### DIFF
--- a/src/constants.cairo
+++ b/src/constants.cairo
@@ -9,3 +9,15 @@ const OPTION_PUT: felt252 = 1;
 const TRADE_SIDE_LONG: felt252 = 0;
 const TRADE_SIDE_SHORT: felt252 = 1;
 const PROPOSAL_VOTING_SECONDS: u64 = consteval_int!(60 * 60 * 24 * 7);
+
+
+// ADDRESSES
+
+const USDC_ADDRESS: felt252 = 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8;
+const ETH_ADDRESS: felt252 = 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7;
+const BTC_ADDRESS: felt252 = 0x03fe2b97c1fd336e750087d68b9b867997fd64a2661ff3ca5a7c771641e8e7ac;
+
+// CLASS HASHES
+
+const LP_TOKEN_CLASS_HASH: felt252 = 0x0; // TODO
+const AMM_CLASS_HASH: felt252 = 0x0; // TODO

--- a/src/contract.cairo
+++ b/src/contract.cairo
@@ -40,7 +40,7 @@ mod Governance {
     use governance::types::ContractType;
     use governance::types::PropDetails;
     use governance::upgrades::Upgrades;
-    use governance::deploy_amm::Deploy_AMM;
+    use governance::deploy_amm::DeployAMM;
     use governance::airdrop::airdrop as airdrop_component;
 
     use starknet::ContractAddress;
@@ -145,7 +145,7 @@ mod Governance {
         }
 
         fn deploy_new_amm(ref self: ContractState) {
-            Deploy_AMM::deploy_amm()
+            DeployAMM::deploy_amm()
         }
     }
 }

--- a/src/deploy_amm.cairo
+++ b/src/deploy_amm.cairo
@@ -1,11 +1,9 @@
-mod Deploy_AMM {
+mod DeployAMM {
     use core::traits::TryInto;
     use core::starknet::SyscallResultTrait;
     use cubit::f128::types::{Fixed, FixedTrait};
 
-    use governance::traits::{
-        IAMMDispatcher, IAMMDispatcherTrait
-    };
+    use governance::traits::{IAMMDispatcher, IAMMDispatcherTrait};
 
     use starknet::syscalls::deploy_syscall;
     use starknet::{ClassHash, ContractAddress};
@@ -19,14 +17,17 @@ mod Deploy_AMM {
     use governance::contract::Governance::proposal_initializer_runContractMemberStateTrait;
     use governance::contract::Governance::amm_addressContractMemberStateTrait;
     use governance::options::Options;
-    
+    use governance::constants::{
+        AMM_CLASS_HASH, LP_TOKEN_CLASS_HASH, ETH_ADDRESS, USDC_ADDRESS, BTC_ADDRESS
+    };
+
 
     // Deploys new AMM, sets AMM address storage var to new AMM, adds lptokens, etc etc etc
     fn deploy_amm() {
-        
-        let amm_class: ClassHash = 0x01.try_into().unwrap(); // TODO
+        let amm_class: ClassHash = AMM_CLASS_HASH.try_into().unwrap(); // TODO
         let voladjspd_eth_call_lpt: felt252 = 15; // TODO check, no increase??
-        let voladjspd_eth_put_lpt: felt252 = 25000; // TODO check, no increase?? // also BTC put pool
+        let voladjspd_eth_put_lpt: felt252 =
+            25000; // TODO check, no increase?? // also BTC put pool
         // 1 BTC voladjspd for btc call pool
 
         let mut state = Governance::unsafe_new_contract_state();
@@ -34,30 +35,71 @@ mod Deploy_AMM {
         state.proposal_initializer_run.write(45, true);
 
         let governance_addr = get_contract_address();
-        let usdc_addr: ContractAddress = 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8.try_into().unwrap();
-        let eth_addr: ContractAddress = 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7.try_into().unwrap();
-        let btc_addr: ContractAddress = 0x03fe2b97c1fd336e750087d68b9b867997fd64a2661ff3ca5a7c771641e8e7ac.try_into().unwrap();
+        let usdc_addr: ContractAddress = USDC_ADDRESS.try_into().unwrap();
+        let eth_addr: ContractAddress = ETH_ADDRESS.try_into().unwrap();
+        let btc_addr: ContractAddress = BTC_ADDRESS.try_into().unwrap();
 
         let mut amm_calldata = ArrayTrait::<felt252>::new();
         amm_calldata.append(governance_addr.into());
         let amm_deploy_retval = deploy_syscall(amm_class, 42, amm_calldata.span(), false);
         let (amm_addr, _) = amm_deploy_retval.unwrap_syscall();
         state.amm_address.write(amm_addr);
-        let amm = IAMMDispatcher{ contract_address: amm_addr };
+        let amm = IAMMDispatcher { contract_address: amm_addr };
 
-        
-        let eth_call_lpt_addr = deploy_lptoken(amm, 'Carmine ETH/USDC call pool', 'C-ETHUSDC-C', usdc_addr, eth_addr, 0, FixedTrait::from_unscaled_felt(voladjspd_eth_call_lpt));
-        let eth_put_lpt_addr = deploy_lptoken(amm, 'Carmine ETH/USDC put pool', 'C-ETHUSDC-P', usdc_addr, eth_addr, 1, FixedTrait::from_unscaled_felt(voladjspd_eth_put_lpt));
-        let btc_call_lpt_addr = deploy_lptoken(amm, 'Carmine BTC/USDC call pool', 'C-BTCUSDC-C', usdc_addr, btc_addr, 0, FixedTrait::ONE());
-        let btc_put_lpt_addr = deploy_lptoken(amm, 'Carmine BTC/USDC put pool', 'C-BTCUSDC-P', usdc_addr, btc_addr, 1, FixedTrait::from_unscaled_felt(voladjspd_eth_put_lpt));
+        let eth_call_lpt_addr = deploy_lptoken(
+            amm,
+            'Carmine ETH/USDC call pool',
+            'C-ETHUSDC-C',
+            usdc_addr,
+            eth_addr,
+            0,
+            FixedTrait::from_unscaled_felt(voladjspd_eth_call_lpt)
+        );
+        let eth_put_lpt_addr = deploy_lptoken(
+            amm,
+            'Carmine ETH/USDC put pool',
+            'C-ETHUSDC-P',
+            usdc_addr,
+            eth_addr,
+            1,
+            FixedTrait::from_unscaled_felt(voladjspd_eth_put_lpt)
+        );
+        let btc_call_lpt_addr = deploy_lptoken(
+            amm,
+            'Carmine BTC/USDC call pool',
+            'C-BTCUSDC-C',
+            usdc_addr,
+            btc_addr,
+            0,
+            FixedTrait::ONE()
+        );
+        let btc_put_lpt_addr = deploy_lptoken(
+            amm,
+            'Carmine BTC/USDC put pool',
+            'C-BTCUSDC-P',
+            usdc_addr,
+            btc_addr,
+            1,
+            FixedTrait::from_unscaled_felt(voladjspd_eth_put_lpt)
+        );
 
         set_trading_halt_permissions(amm);
 
-        Options::add_1201_options(eth_call_lpt_addr, eth_put_lpt_addr, btc_call_lpt_addr, btc_put_lpt_addr);
+        Options::add_1201_options(
+            eth_call_lpt_addr, eth_put_lpt_addr, btc_call_lpt_addr, btc_put_lpt_addr
+        );
     }
 
-    fn deploy_lptoken(amm: IAMMDispatcher, name: felt252, symbol: felt252, quote_token_address: ContractAddress, base_token_address: ContractAddress, option_type: OptionType, voladjspd: Fixed) -> ContractAddress {
-        let lptoken_class: ClassHash = 0x0.try_into().unwrap(); // TODO
+    fn deploy_lptoken(
+        amm: IAMMDispatcher,
+        name: felt252,
+        symbol: felt252,
+        quote_token_address: ContractAddress,
+        base_token_address: ContractAddress,
+        option_type: OptionType,
+        voladjspd: Fixed
+    ) -> ContractAddress {
+        let lptoken_class: ClassHash = LP_TOKEN_CLASS_HASH.try_into().unwrap();
         let mut lpt_calldata: Array<felt252> = ArrayTrait::<felt252>::new();
         lpt_calldata.append('Carmine ETH/USDC call pool');
         lpt_calldata.append('C-ETHUSDC-C');
@@ -66,23 +108,41 @@ mod Deploy_AMM {
         let deploy_retval = deploy_syscall(lptoken_class, 0, lpt_calldata.span(), false);
         let (lpt_addr, _) = deploy_retval.unwrap_syscall();
         let voladj_new = voladjspd;
-        amm.add_lptoken(quote_token_address, base_token_address, option_type.into(), lpt_addr, voladj_new, BoundedInt::max());
+        amm
+            .add_lptoken(
+                quote_token_address,
+                base_token_address,
+                option_type.into(),
+                lpt_addr,
+                voladj_new,
+                BoundedInt::max()
+            );
 
         lpt_addr
     }
 
     fn set_trading_halt_permissions(amm: IAMMDispatcher) {
         let mut team_addresses: Array<felt252> = ArrayTrait::new();
-        team_addresses.append(0x0583a9d956d65628f806386ab5b12dccd74236a3c6b930ded9cf3c54efc722a1); // Ondra
-        team_addresses.append(0x06717eaf502baac2b6b2c6ee3ac39b34a52e726a73905ed586e757158270a0af); // Andrej
-        team_addresses.append(0x0011d341c6e841426448ff39aa443a6dbb428914e05ba2259463c18308b86233); // Marek
-        team_addresses.append(0x00d79a15d84f5820310db21f953a0fae92c95e25d93cb983cc0c27fc4c52273c); // Marek second
-        team_addresses.append(0x03d1525605db970fa1724693404f5f64cba8af82ec4aab514e6ebd3dec4838ad); // David
+        team_addresses
+            .append(0x0583a9d956d65628f806386ab5b12dccd74236a3c6b930ded9cf3c54efc722a1); // Ondra
+        team_addresses
+            .append(0x06717eaf502baac2b6b2c6ee3ac39b34a52e726a73905ed586e757158270a0af); // Andrej
+        team_addresses
+            .append(0x0011d341c6e841426448ff39aa443a6dbb428914e05ba2259463c18308b86233); // Marek
+        team_addresses
+            .append(
+                0x00d79a15d84f5820310db21f953a0fae92c95e25d93cb983cc0c27fc4c52273c
+            ); // Marek second
+        team_addresses
+            .append(0x03d1525605db970fa1724693404f5f64cba8af82ec4aab514e6ebd3dec4838ad); // David
 
         loop {
             match team_addresses.pop_front() {
                 Option::Some(team_address) => {
-                    amm.set_trading_halt_permission(team_address.try_into().expect('invalid addr'), true);
+                    amm
+                        .set_trading_halt_permission(
+                            team_address.try_into().expect('invalid addr'), true
+                        );
                 },
                 Option::None(()) => { break (); },
             };


### PR DESCRIPTION
Moves addresses and class hashes to one place, this should minimize the chance of missing a hash that needs to be updated.

- renames `Deploy_AMM` to `DeployAMM`